### PR TITLE
Not waiting for the window to open

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -34,7 +34,7 @@ export class Actions {
     public static openArticle(id: number): void {
         const article = this.storage.getArticle(id);
         if (article) {
-            opn(article.url).then(() =>
+            opn(article.url, {wait: false}).then(() =>
                 console.info("Article opened in your default browser."),
             );
         } else {
@@ -151,7 +151,7 @@ export class Actions {
                         return titles.includes(article.title);
                     });
                     art.forEach((article) => {
-                        opn(article.url).then(() =>
+                        opn(article.url, {wait: false}).then(() =>
                             console.info(
                                 `Article #${
                                     article.id


### PR DESCRIPTION
Hee @Leoat12,

First of all, great work so far! I was about to write a similar tool when i found your project. 😃
I noticed on Mac OS that it never executes the callbacks of 'opn' and my terminal command will never return.. 
This is at least on Mac OS fixed by passing `{ wait: false }`. This basically means that we will not wait for the window to open, there is no way of knowing that. There are multiple issues about this on the opn repository.

I really like the project and the idea so i might drop some more PR's 😉 

Thanks!