### PR TITLE
Show help on none or incorrect command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ git clone https://github.com/Leoat12/toread-cli.git
 3. Run this :
 
 ```
-$ cd toread-cli && npm install
+$ cd toread-cli && npm install && npm run build
 ```
 
 4. Then install it as npm package :

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,4 +89,8 @@ Commander.command("delete")
     Actions.deleteAll();
   });
 
+if (!process.argv.slice(2).length) {
+    Commander.help();
+}
+
 Commander.parse(process.argv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,10 @@ Commander.command("delete")
     Actions.deleteAll();
   });
 
+Commander.on("command:*", () => {
+    console.error("Invalid command: %s\nSee --help for a list of available commands.", Commander.args.join(" "));
+});
+
 if (!process.argv.slice(2).length) {
     Commander.help();
 }


### PR DESCRIPTION
Currently when you pass in no action/command currently it just returns without any output.
```bash
$ to-read
 
```

It's common practice for CLI tools to show how to use it when used incorrectly or a wrong command is passed in. This small change outputs the same output as `--help` does when no action is passed to the tool. 

And the following when an incorrect command is passed:

```bash
$ to-read blabla
Invalid command: blabla
See --help for a list of available commands.
```

Also i added the `npm run build` step to the installation steps in the readme, there is no `lib` folder after running `npm install` 😉 