### PR TITLE
Adding counter option to list command

### DIFF
--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -40,6 +40,10 @@ $ to-read list | ls
 
 > See the list of articles you saved.
 
+##### \***_Opt_** :
+
+- `--count | -c` Retrieve a number of the amount of articles still left to read.
+
 #### # `searchTag`
 
 ```

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -9,8 +9,14 @@ import {Display, PresentationMode} from "./display";
 import {Storage} from "./storage";
 
 export class Actions {
-    public static getArticles(): void {
+    public static getArticles(options: { count: number }): void {
         const articles: Article[] = this.storage.getArticles();
+
+        if (options.count) {
+            Display.printArticleCount(articles.length);
+            return;
+        }
+
         if (articles.length < 1) {
             Display.printGetArticlesErrorMessage();
         } else {
@@ -155,7 +161,7 @@ export class Actions {
                             console.info(
                                 `Article #${
                                     article.id
-                                } opened in your default browser.`,
+                                    } opened in your default browser.`,
                             ),
                         );
                     });

--- a/src/display.ts
+++ b/src/display.ts
@@ -1,6 +1,7 @@
 import colors from "colors";
 
-import { Article } from "./article";
+import {Article} from "./article";
+import * as inquirer from "inquirer";
 
 export enum PresentationMode {
     LIST,
@@ -13,8 +14,8 @@ export class Display {
             if (article.id) {
                 console.info(
                     colors.bold.underline.green(`#${article.id.toString()}`) +
-                        colors.bold.underline.green(` ${article.title}`) +
-                        colors.red(` -> ${article.status}`),
+                    colors.bold.underline.green(` ${article.title}`) +
+                    colors.red(` -> ${article.status}`),
                 );
                 this.printTags(article.tags);
                 console.info("\n");
@@ -80,6 +81,10 @@ export class Display {
                 ),
             );
         }
+    }
+
+    public static printArticleCount(count: number) {
+        console.info(count);
     }
 
     public static printSaveArticleExistingArticleMessage() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,86 +7,95 @@ import {Status} from "./article";
 Commander.version("1.0.0").description("To Read Project CLI");
 
 Commander.command("list")
-  .alias("ls")
-  .description("List all articles")
-  .action(() => {
-    Actions.getArticles();
-  });
+    .alias("ls")
+    .description("List all articles")
+    .option("-c, --count", "Show the amount of articles still left to read.")
+    .action((options) => {
+        Actions.getArticles(options);
+    });
 
 Commander.command("searchTag <tag>")
     .alias("st")
     .description("Search articles by the tag given")
     .action((tag: string) => {
-       Actions.getArticlesByTag(tag);
+        Actions.getArticlesByTag(tag);
     });
 
 Commander.command("open <id>")
-  .alias("o")
-  .description("Open the article in the default browser.")
-  .action((id: number) => {
-    Actions.openArticle(id);
-  });
+    .alias("o")
+    .description("Open the article in the default browser.")
+    .action((id: number) => {
+        Actions.openArticle(id);
+    });
 
 Commander.command("saveArticle <url>")
-  .alias("sa")
-  .option("-i, --information <info>", "Description of the article.")
-  .option("-t, --tags <tags>", "Tags separated by comma.")
-  .description("Saves an article.")
-  .action((url: string, cmd: Command) => {
-    const description: string = cmd.opts()["information"];
-    const tags: string = cmd.opts()["tags"];
-    Actions.saveArticle(url, description, tags);
-  });
+    .alias("sa")
+    .option("-i, --information <info>", "Description of the article.")
+    .option("-t, --tags <tags>", "Tags separated by comma.")
+    .description("Saves an article.")
+    .action((url: string, cmd: Command) => {
+        const description: string = cmd.opts()["information"];
+        const tags: string = cmd.opts()["tags"];
+        Actions.saveArticle(url, description, tags);
+    });
 
 Commander.command("updateArticle <id>")
-  .alias("ua")
-  .option("-i, --information <info>", "Description of the article.")
-  .option("-t, --tags <tags>", "Tags separated by comma.")
-  .option(
-    "-a, --addTags <addTags>",
-    "Whether or not the tags given will be deleted (false) or added (true)",
-  )
-  .option(
-    "-s, --status <status>",
-    "The status of article: 'TO READ', 'READING' or 'READ'",
-  )
-  .description(
-    "Update an article's information. Only description, tags and status can be changed.",
-  )
-  .action((id: number, cmd: Command) => {
-    const description: string = cmd.opts()["information"];
-    const tags: string = cmd.opts()["tags"];
-    const addTags: boolean = cmd.opts()["addTags"] === "true";
-    const status: Status = cmd.opts()["status"];
-    Actions.updateArticle(id, addTags, description, tags, status);
-  });
+    .alias("ua")
+    .option("-i, --information <info>", "Description of the article.")
+    .option("-t, --tags <tags>", "Tags separated by comma.")
+    .option(
+        "-a, --addTags <addTags>",
+        "Whether or not the tags given will be deleted (false) or added (true)",
+    )
+    .option(
+        "-s, --status <status>",
+        "The status of article: 'TO READ', 'READING' or 'READ'",
+    )
+    .description(
+        "Update an article's information. Only description, tags and status can be changed.",
+    )
+    .action((id: number, cmd: Command) => {
+        const description: string = cmd.opts()["information"];
+        const tags: string = cmd.opts()["tags"];
+        const addTags: boolean = cmd.opts()["addTags"] === "true";
+        const status: Status = cmd.opts()["status"];
+        Actions.updateArticle(id, addTags, description, tags, status);
+    });
 
 Commander.command("deleteArticle <id>")
-  .alias("da")
-  .description("Delete the article with the given ID")
-  .action((id: number) => {
-    Actions.deleteArticle(id);
-  });
+    .alias("da")
+    .description("Delete the article with the given ID")
+    .action((id: number) => {
+        Actions.deleteArticle(id);
+    });
 
 Commander.command("clearStorage")
-  .alias("cla")
-  .description("Delete all articles")
-  .action(() => {
-    Actions.clearArticles();
-  });
+    .alias("cla")
+    .description("Delete all articles")
+    .action(() => {
+        Actions.clearArticles();
+    });
 
 Commander.command("opens")
-  .alias("ops")
-  .description("Open the selected article in the default browser.")
-  .action(() => {
-    Actions.openAll();
-  });
+    .alias("ops")
+    .description("Open the selected article in the default browser.")
+    .action(() => {
+        Actions.openAll();
+    });
 
 Commander.command("delete")
-  .alias("dlt")
-  .description("Delete the selected article.")
-  .action(() => {
-    Actions.deleteAll();
-  });
+    .alias("dlt")
+    .description("Delete the selected article.")
+    .action(() => {
+        Actions.deleteAll();
+    });
+
+Commander.on("command:*", () => {
+    console.error("Invalid command: %s\nSee --help for a list of available commands.", Commander.args.join(" "));
+});
+
+if (!process.argv.slice(2).length) {
+    Commander.help();
+}
 
 Commander.parse(process.argv);


### PR DESCRIPTION
This option makes it possible to retrieve the count of the amount of articles left on your list. 

```bash
# Example with 1 article on the list
$ to-read ls --count
1
```

This is mainly for scripting purposes. For example use this to show it in your bash prompt to indicate you still have articles to read.